### PR TITLE
aspnetcore update index migration link

### DIFF
--- a/aspnetcore/index.md
+++ b/aspnetcore/index.md
@@ -96,7 +96,7 @@ We recommend the following sequence of tutorials and articles for an introductio
 
 ## Migration from the .NET Framework
 
-For a reference guide to migrating ASP.NET apps to ASP.NET Core, see <migration/proper-to-2x/index>.
+For a reference guide to migrating ASP.NET apps to ASP.NET Core, see [Migrate from ASP.NET to ASP.NET Core](xref:migration/proper-to-2x/index).
 
 ## How to download a sample
 

--- a/aspnetcore/index.md
+++ b/aspnetcore/index.md
@@ -96,7 +96,7 @@ We recommend the following sequence of tutorials and articles for an introductio
 
 ## Migration from the .NET Framework
 
-For a reference guide to migrating ASP.NET apps to ASP.NET Core, see [Migrate from ASP.NET to ASP.NET Core](xref:migration/proper-to-2x/index).
+For a reference guide to migrating ASP.NET apps to ASP.NET Core, see <xref:migration/proper-to-2x/index>.
 
 ## How to download a sample
 


### PR DESCRIPTION
In Migration from the .NET Framework the link to ASP core migration was broken
